### PR TITLE
Add test helpers

### DIFF
--- a/lib/grade_runner.rb
+++ b/lib/grade_runner.rb
@@ -6,7 +6,6 @@ require "grade_runner/services/github_service"
 require "grade_runner/services/spec_service"
 require "grade_runner/services/grade_service"
 require "grade_runner/railtie" if defined?(Rails)
-require "grade_runner/test_helpers"
 
 module GradeRunner
   class Error < StandardError; end

--- a/lib/grade_runner.rb
+++ b/lib/grade_runner.rb
@@ -6,6 +6,7 @@ require "grade_runner/services/github_service"
 require "grade_runner/services/spec_service"
 require "grade_runner/services/grade_service"
 require "grade_runner/railtie" if defined?(Rails)
+require "grade_runner/test_helpers"
 
 module GradeRunner
   class Error < StandardError; end

--- a/lib/grade_runner/test_helpers.rb
+++ b/lib/grade_runner/test_helpers.rb
@@ -153,5 +153,28 @@ module GradeRunner
     def run_script_with_input(path, input)
       with_stdin(input) { run_script(path) }
     end
+
+    ##
+    # Remove comment-only lines from a source string.
+    #
+    # This is useful in specs when you want to assert that a script
+    # uses certain operators (`+`, `-`, `%`, etc.) without matching
+    # against instructional comments.
+    #
+    # @param src [String] the file contents
+    # @return [String] source with comment-only lines removed
+    #
+    # @example
+    #   src = <<~RUBY
+    #     # add two numbers
+    #     x + y
+    #   RUBY
+    #
+    #   strip_comments(src)
+    #   # => "x + y\n"
+    #
+    def strip_comments(src)
+      src.lines.reject { |line| line.strip.start_with?("#") }.join
+    end
   end
 end

--- a/lib/grade_runner/test_helpers.rb
+++ b/lib/grade_runner/test_helpers.rb
@@ -86,7 +86,6 @@ module GradeRunner
       stdout, _stderr, _status = run_script(path, stdin: stdin)
       normalize_output(stdout)
     end
-    alias pp_lines_from_capture3 pp_lines_from_run
 
     ##
     # Remove quotes, split into lines, strip, and reject empties.

--- a/lib/grade_runner/test_helpers.rb
+++ b/lib/grade_runner/test_helpers.rb
@@ -25,8 +25,7 @@ module GradeRunner
 
     ##
     # Run a Ruby script in-process (like `ruby file.rb`) while capturing
-    # its stdout, stderr, and exitstatus. This is similar to
-    # Open3.capture3 but plays nicely with RSpec mocks.
+    # its stdout, stderr, and exitstatus.
     #
     # @param path [String] path to the script (e.g., "./calculator.rb")
     # @param stdin [String] content fed into gets/$stdin (include "\n")
@@ -68,7 +67,6 @@ module GradeRunner
 
       [out_buf.string, err_buf.string, status]
     end
-    alias capture3_ruby run_script
 
     ##
     # Run a script and return normalized pp/puts lines:
@@ -108,7 +106,6 @@ module GradeRunner
     def run_file(path)
       capture_stdout { load path }
     end
-    alias run_script run_file
 
     ##
     # Capture standard output (and optionally stderr) while running a block.

--- a/lib/grade_runner/test_helpers.rb
+++ b/lib/grade_runner/test_helpers.rb
@@ -118,5 +118,40 @@ module GradeRunner
       end
       normalize_output(run_script(file_path))
     end
+
+    ##
+    # Temporarily replace $stdin with a StringIO seeded with given input.
+    #
+    # @param input [String] text that will be returned by gets/lines/etc.
+    # @yield block that will run with $stdin replaced
+    # @return [Object] block return value
+    #
+    # @example
+    #   with_stdin("7\n3\n") do
+    #     x = gets.to_i  # => 7
+    #     y = gets.to_i  # => 3
+    #   end
+    #
+    def with_stdin(input)
+      original_stdin = $stdin
+      $stdin = StringIO.new(input)
+      yield
+    ensure
+      $stdin = original_stdin
+    end
+
+    ##
+    # Run a Ruby script with provided stdin content, capturing its stdout.
+    #
+    # @param path [String] path to the script (e.g., "./calculator.rb")
+    # @param input [String] text passed to $stdin
+    # @return [String] captured stdout
+    #
+    # @example
+    #   output = run_script_with_input("./calculator.rb", "7\n3\n")
+    #
+    def run_script_with_input(path, input)
+      with_stdin(input) { run_script(path) }
+    end
   end
 end

--- a/lib/grade_runner/test_helpers.rb
+++ b/lib/grade_runner/test_helpers.rb
@@ -1,0 +1,133 @@
+# lib/grade_runner/test_helpers.rb
+require "stringio"
+
+module GradeRunner
+  ##
+  # TestHelpers provides small utilities for writing exercise specs
+  # that need to capture program output or temporarily modify the
+  # runtime environment. These helpers are designed to make specs
+  # shorter, clearer, and more consistent across projects.
+  #
+  # Example usage (RSpec):
+  #
+  #   RSpec.configure do |config|
+  #     config.include GradeRunner::TestHelpers
+  #   end
+  #
+  #   it "captures script output" do
+  #     output = capture_output_of("./hello.rb")
+  #     expect(output).to eq("\"hello, world\"\n")
+  #   end
+  #
+  module TestHelpers
+    ##
+    # Capture standard output (and optionally standard error) while
+    # executing a block.
+    #
+    # @param capture_stderr [Boolean] whether to also capture $stderr
+    # @yield block of code to execute
+    # @return [String] captured STDOUT if capture_stderr: false
+    # @return [Array<String,String>] [STDOUT, STDERR] if capture_stderr: true
+    #
+    # @example
+    #   output = capture_stdout { puts "hi" }
+    #   # => "hi\n"
+    #
+    #   out, err = capture_stdout(capture_stderr: true) do
+    #     puts "ok"
+    #     warn "oops"
+    #   end
+    #   # out = "ok\n"
+    #   # err = "oops\n"
+    #
+    def capture_stdout(capture_stderr: false)
+      orig_out, orig_err = $stdout, $stderr
+      out_buf = StringIO.new
+      err_buf = capture_stderr ? StringIO.new : nil
+
+      $stdout = out_buf
+      $stderr = err_buf if capture_stderr
+
+      yield
+
+      capture_stderr ? [out_buf.string, err_buf.string] : out_buf.string
+    ensure
+      $stdout = orig_out
+      $stderr = orig_err if capture_stderr
+    end
+
+    ##
+    # Convenience alias for capture_stdout with capture_stderr: true.
+    #
+    # @yield block of code to execute
+    # @return [Array<String,String>] [STDOUT, STDERR]
+    #
+    # @example
+    #   out, err = capture_io { puts "ok"; warn "oops" }
+    #
+    def capture_io(&block)
+      capture_stdout(capture_stderr: true, &block)
+    end
+
+    ##
+    # Load a Ruby file (like "ruby file.rb") and capture its output.
+    #
+    # This is especially useful for testing beginner exercises
+    # where the code lives in a standalone script and prints with pp/puts.
+    #
+    # @param file_path [String] path to the file to load
+    # @param capture_stderr [Boolean] whether to also capture $stderr
+    # @return [String, Array<String,String>] captured output
+    #
+    # @example
+    #   output = capture_output_of("./hello.rb")
+    #   expect(output).to eq("\"hello, world\"\n")
+    #
+    def capture_output_of(file_path, capture_stderr: false)
+      capture_stdout(capture_stderr: capture_stderr) { load file_path }
+    end
+
+    ##
+    # Temporarily set environment variables within a block.
+    #
+    # Original values are restored afterward, even if the block raises.
+    #
+    # @param hash [Hash{String,Symbol=>String,nil}] ENV vars to override
+    # @yield block to run with modified ENV
+    #
+    # @example
+    #   with_env("LUCKY" => "14") do
+    #     output = capture_output_of("./lucky_number.rb")
+    #     expect(output).to include("14")
+    #   end
+    #
+    def with_env(hash)
+      old = {}
+      hash.each { |k, v| old[k] = ENV[k]; ENV[k] = v }
+      yield
+    ensure
+      old.each { |k, v| ENV[k] = v }
+    end
+
+    ##
+    # Temporarily change the current working directory for a block.
+    #
+    # Useful when testing scripts that assume a particular relative path.
+    #
+    # @param dir [String] directory to change into
+    # @yield block to run inside the directory
+    #
+    # @example
+    #   with_chdir("examples") do
+    #     output = capture_output_of("./script.rb")
+    #   end
+    #
+    def with_chdir(dir)
+      old = Dir.pwd
+      Dir.chdir(dir)
+      yield
+    ensure
+      Dir.chdir(old)
+    end
+  end
+end


### PR DESCRIPTION
TestHelpers provides small utilities for writing exercise specs that need to capture program output. These helpers keep specs short, readable, and consistent across projects.